### PR TITLE
Add 0.2 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ There is full API support for **wasm** and **native**. Android and iOS are untes
 
 |bevy|bevy_key_rotation|
 |---|---|
-|0.13|0.1, main|
+|0.14|0.2, main|
+|0.13|0.1|
 |< 0.13|Unsupported|
 
 ## Usage


### PR DESCRIPTION
Hi there! I was looking around Loopy's crates and noticed that the README for this one didn't mention 0.2 in the table. This is just a quick fix for that 🙂 